### PR TITLE
Added null map checks for on-death belts

### DIFF
--- a/Source/VAE Accessories/VAE Accessories/Comps/CompExplodeOnDeath.cs
+++ b/Source/VAE Accessories/VAE Accessories/Comps/CompExplodeOnDeath.cs
@@ -12,7 +12,8 @@ namespace VAE_Accessories
 
         public void ExplodeOnDeath(Pawn pawn)
         {
-            GenExplosion.DoExplosion(pawn.Position, pawn.Map, Props.explosionRadius, Props.damageDef, pawn);
+            if (pawn.Map != null)
+                GenExplosion.DoExplosion(pawn.Position, pawn.Map, Props.explosionRadius, Props.damageDef, pawn);
         }
     }
 }

--- a/Source/VAE Accessories/VAE Accessories/UtilityMethods.cs
+++ b/Source/VAE Accessories/VAE Accessories/UtilityMethods.cs
@@ -17,10 +17,10 @@ namespace VAE_Accessories
             if (pawn.Map != null)
             {
                 for (var i = 0; i < 10; i++) FleckMaker.ThrowAirPuffUp(pawn.DrawPos, pawn.Map);
+                if (pawn.Faction != null && pawn.Faction != Faction.OfPlayer && pawn.HostileTo(Faction.OfPlayer))
+                    LordMaker.MakeNewLord(pawn.Faction, new LordJob_AssaultColony(pawn.Faction), pawn.Map,
+                        Gen.YieldSingle(pawn));
             }
-            if (pawn.Faction != null && pawn.Faction != Faction.OfPlayer && pawn.HostileTo(Faction.OfPlayer))
-                LordMaker.MakeNewLord(pawn.Faction, new LordJob_AssaultColony(pawn.Faction), pawn.Map,
-                    Gen.YieldSingle(pawn));
             if (pawn.apparel != null)
             {
                 var wornApparel = pawn.apparel.WornApparel;


### PR DESCRIPTION
`CompExplodeOnDeath` will only explode if the Pawn's map is not null. `ResurrectorBelt` will not attempt to make a lord if the map is null.

This should fix some potential warning (possibly errors?) during map generation.