### PR TITLE
Replace `TryGetComp` call with `GetComp`

### DIFF
--- a/Source/VAE Accessories/VAE Accessories/HarmonyPatches.cs
+++ b/Source/VAE Accessories/VAE Accessories/HarmonyPatches.cs
@@ -23,7 +23,7 @@ namespace VAE_Accessories
             for (var i = __instance.apparel.WornApparel.Count - 1; i >= 0; --i)
             {
                 var apparel = __instance.apparel.WornApparel[i];
-                if (apparel.TryGetComp<CompExplodeOnDeath>() is CompExplodeOnDeath comp)
+                if (apparel.GetComp<CompExplodeOnDeath>() is CompExplodeOnDeath comp)
                     comp.ExplodeOnDeath(__instance);
                 else if (apparel is ResurrectorBelt)
                 {


### PR DESCRIPTION
As long as we're working on `ThingWithComps` (or its subtype) there's not really a reason to use `TryGetComp`. Probably meaningless, but why not slightly improve the code I guess?